### PR TITLE
Create macros for id and secret types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,16 @@ updates:
       - C-dependency
       - L-github
       - R-ignore
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-github
+      - R-ignore

--- a/.github/workflows/push-rust.yml
+++ b/.github/workflows/push-rust.yml
@@ -95,13 +95,13 @@ jobs:
         if: ${{ steps.coverage.outputs.enable != 'true' }}
         with:
           command: test
-          args: --verbose
+          args: --verbose --all-features
 
       - name: Run tests with test coverage
         uses: actions-rs/tarpaulin@master
         if: ${{ steps.coverage.outputs.enable == 'true' }}
         with:
-          args: --skip-clean
+          args: --skip-clean --all-features
           version: 0.20.0
 
       - name: Upload to codecov.io
@@ -116,3 +116,28 @@ jobs:
         with:
           name: code-coverage-report
           path: cobertura.xml
+
+  test-features:
+    name: Test all feature combinations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache build artifacts
+        uses: swatinem/rust-cache@v2.0.1
+
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+
+      - name: Run cargo-all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test-all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+---
+name: Release
+
+"on":
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache build artifacts
+        uses: swatinem/rust-cache@v2.0.0
+
+      - name: Publish to crates.io
+        run: cargo publish -v --all-features --token ${{ secrets.CRATES_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,15 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.28.0
     hooks:
       - id: yamllint
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.32.2
     hooks:
       - id: markdownlint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
   - repo: https://github.com/doublify/pre-commit-rust
@@ -39,7 +39,7 @@ repos:
       - id: fmt
         args: [--all, --]
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.6
+    rev: 3.0.0
     hooks:
       - id: shellcheck
         name: shellcheck

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "idtype"
+version = "0.0.0"
+edition = "2021"
+
+# Required to declare a weak dependency on the `secrecy/serde` feature
+# https://doc.rust-lang.org/cargo/reference/features.html#dependency-features
+rust-version = "1.60"
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+secrecy = ["dep:secrecy"]
+serde = ["dep:serde", "secrecy?/serde"]
+
+[dependencies]
+secrecy = { version = "0.8", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2022 DEV x BOTS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,51 @@
-# 📦 Template
+# 🪪 `idtype`
 
-_A pre-configured template repository for DEV x BOTS._
+[![Crates.io](https://img.shields.io/crates/v/idtype)](https://crates.io/crates/idtype)
+[![docs.rs](https://img.shields.io/docsrs/idtype)][documentation]
 
-This repository is pre-configured with default tooling and configurations for
-the [DEV x BOTS] organization, and it can be used as a template repository to
-quickly bootstrap new projects.
+`idtype` provides convenient macros to use the [`newtype`] pattern to generate
+types for identifiers.
+
+## Usage
+
+The crate provides three macros to generate identifier types:
+
+- `id!` can be used for numerical ids
+- `name!` can be used for unique usernames or string-based ids
+- `secret!` can be used for sensitive strings like passwords
+
+The generated types implement a few common traits so that they can be easily
+converted from and to their inner types.
+
+```rust
+use idtype::id;
+
+id!(
+    /// A numeric id
+    Id
+);
+
+fn main() {
+    let id: Id = 42.into();
+}
+```
+
+Check out the crate's [documentation] for more information.
 
 ## License
 
-Copyright (c) 2022 Jan David Nose. All rights reserved.
+Licensed under either of
 
-[dev x bots]: https://github.com/devxbots
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[`newtype`]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
+[documentation]: https://docs.rs/idtype

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,324 @@
+/// Generate a numeric id type
+///
+/// The `id!` macro generates a numeric id type that wraps a `u64`. The type implements common
+/// traits and conversations that make it easy to use.
+///
+/// # Example
+///
+/// ```rust
+/// use idtype::id;
+///
+/// id!(UserId);
+///
+/// let id: UserId = 42.into();
+/// println!("User {} registered", id);
+/// ```
+#[macro_export]
+macro_rules! id {
+    (
+        $(#[$meta:meta])*
+        $id:ident
+    ) => {
+        $(#[$meta])*
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        pub struct $id(u64);
+
+        impl $id {
+            /// Initializes a new id.
+            pub fn new(id: u64) -> Self {
+                Self(id)
+            }
+
+            /// Returns the inner value of the id.
+            pub fn get(&self) -> u64 {
+                self.0
+            }
+        }
+
+        impl std::fmt::Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<u64> for $id {
+            fn from(id: u64) -> $id {
+                $id(id)
+            }
+        }
+    };
+}
+
+/// Generate a string type
+///
+/// The `name!` macro generates a string type. The type implements common traits and conversations
+/// that make it easy to use.
+///
+/// # Example
+///
+/// ```rust
+/// use idtype::name;
+///
+/// name!(Username);
+///
+/// let username: Username = "jdno".into();
+/// println!("User {} registered", username);
+/// ```
+#[macro_export]
+macro_rules! name {
+    (
+        $(#[$meta:meta])*
+        $name:ident
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        pub struct $name(String);
+
+        impl $name {
+            /// Initializes a new name.
+            pub fn new(name: &str) -> Self {
+                Self(name.into())
+            }
+
+            /// Returns the inner value of the name.
+            pub fn get(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(string: &str) -> $name {
+                $name(string.into())
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(string: String) -> $name {
+                $name(string)
+            }
+        }
+    };
+}
+
+/// Generate a secret type
+///
+/// The `secret!` macro generates a type for secrets such as passwords or tokens. The type uses the
+/// [`secrecy`](https://crates.io/crates/secrecy) crate internally to prevent accidentally leaking
+/// the inner value in debug or log statements.
+///
+/// # Example
+///
+/// ```rust
+/// use idtype::secret;
+///
+/// secret!(ApiToken);
+///
+/// let token: ApiToken = "super-secret-api-token".into();
+/// let header = format!("Authorization: Bearer {}", token.expose());
+/// ```
+#[cfg(feature = "secrecy")]
+#[macro_export]
+macro_rules! secret {
+    (
+        $(#[$meta:meta])*
+        $secret:ident
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Debug)]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+        pub struct $secret(secrecy::SecretString);
+
+        impl $secret {
+            /// Initializes a new secret.
+            pub fn new(secret: &str) -> Self {
+                Self(secrecy::SecretString::new(String::from(secret)))
+            }
+
+            /// Returns the inner value of the secret.
+            pub fn expose(&self) -> &str {
+                use secrecy::ExposeSecret;
+                self.0.expose_secret()
+            }
+        }
+
+        impl std::fmt::Display for $secret {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "[REDACTED]")
+            }
+        }
+
+        impl From<&str> for $secret {
+            fn from(secret: &str) -> $secret {
+                $secret(secrecy::SecretString::new(String::from(secret)))
+            }
+        }
+
+        impl From<String> for $secret {
+            fn from(secret: String) -> $secret {
+                $secret(secrecy::SecretString::new(secret))
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod id {
+        use super::*;
+
+        id!(
+            /// Identifier for tests
+            TestId
+        );
+
+        #[test]
+        fn id() {
+            let id = TestId::new(42);
+
+            assert_eq!(42, id.get());
+        }
+
+        #[test]
+        fn trait_display() {
+            let id = TestId::new(42);
+
+            assert_eq!("42", id.to_string());
+        }
+
+        #[test]
+        fn trait_from_u64() {
+            let _id: TestId = 42.into();
+        }
+
+        #[test]
+        fn trait_send() {
+            fn assert_send<T: Send>() {}
+            assert_send::<TestId>();
+        }
+
+        #[test]
+        fn trait_sync() {
+            fn assert_sync<T: Sync>() {}
+            assert_sync::<TestId>();
+        }
+
+        #[test]
+        fn trait_unpin() {
+            fn assert_unpin<T: Unpin>() {}
+            assert_unpin::<TestId>();
+        }
+    }
+
+    mod name {
+        use super::*;
+
+        name!(
+            /// Name for tests
+            TestName
+        );
+
+        #[test]
+        fn name() {
+            let name = TestName::new("test");
+
+            assert_eq!("test", name.get());
+        }
+
+        #[test]
+        fn trait_display() {
+            let name = TestName::new("test");
+
+            assert_eq!("test", name.to_string());
+        }
+
+        #[test]
+        fn trait_from_str() {
+            let _name: TestName = "test".into();
+        }
+
+        #[test]
+        fn trait_from_string() {
+            let _name: TestName = String::from("test").into();
+        }
+
+        #[test]
+        fn trait_send() {
+            fn assert_send<T: Send>() {}
+            assert_send::<TestName>();
+        }
+
+        #[test]
+        fn trait_sync() {
+            fn assert_sync<T: Sync>() {}
+            assert_sync::<TestName>();
+        }
+
+        #[test]
+        fn trait_unpin() {
+            fn assert_unpin<T: Unpin>() {}
+            assert_unpin::<TestName>();
+        }
+    }
+
+    #[cfg(feature = "secrecy")]
+    mod secret {
+        use super::*;
+
+        secret!(
+            /// Secret for tests
+            TestSecret
+        );
+
+        #[test]
+        fn secret() {
+            let secret = TestSecret::new("test");
+
+            assert_eq!("test", secret.expose());
+        }
+
+        #[test]
+        fn trait_display() {
+            let secret = TestSecret::new("test");
+
+            assert_eq!("[REDACTED]", secret.to_string());
+        }
+
+        #[test]
+        fn trait_from_str() {
+            let _secret: TestSecret = "test".into();
+        }
+
+        #[test]
+        fn trait_from_string() {
+            let _secret: TestSecret = "test".into();
+        }
+
+        #[test]
+        fn trait_send() {
+            fn assert_send<T: Send>() {}
+            assert_send::<TestSecret>();
+        }
+
+        #[test]
+        fn trait_sync() {
+            fn assert_sync<T: Sync>() {}
+            assert_sync::<TestSecret>();
+        }
+
+        #[test]
+        fn trait_unpin() {
+            fn assert_unpin<T: Unpin>() {}
+            assert_unpin::<TestSecret>();
+        }
+    }
+}


### PR DESCRIPTION
The initial implementation of this crate is extracted from [devxbots/automatons], where the same functionality has been used with success for a while now. As we found ourselves copying the same file around, we decided to finally extract it into its own crate.

The crate implements three macros that can be used to generate Rust types for identifiers or secrets. Using newtypes over type aliases enables the Rust compiler to enforce the type boundaries throughout the program.

[devxbots/automatons]: https://github.com/devxbots/automatons