### PR TITLE
Rename secret feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60"
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-secrecy = ["dep:secrecy"]
+secret = ["dep:secrecy"]
 serde = ["dep:serde", "secrecy?/serde"]
 
 [dependencies]


### PR DESCRIPTION
The macro that generates a secret type is hidden behind a feature flag, since it pulls in additional dependencies. The feature has now been renamed from the name of the external dependency to a name that describes its functionality.