### PR TITLE
Remove optional features from crate

### DIFF
--- a/.github/workflows/push-rust.yml
+++ b/.github/workflows/push-rust.yml
@@ -116,28 +116,3 @@ jobs:
         with:
           name: code-coverage-report
           path: cobertura.xml
-
-  test-features:
-    name: Test all feature combinations
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache build artifacts
-        uses: swatinem/rust-cache@v2.0.1
-
-      - name: Install cargo-all-features
-        run: cargo install cargo-all-features
-
-      - name: Run cargo-all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,12 @@ rust-version = "1.60"
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-secret = ["dep:secrecy"]
-serde = ["dep:serde", "secrecy?/serde"]
-
 [[example]]
 name = "secret"
-required-features = ["secret", "serde"]
 
 [dependencies]
-secrecy = { version = "0.8", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
+secrecy = { version = "0.8", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.87"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+pub use secrecy;
+pub use serde;
+
 /// Generate a numeric id type
 ///
 /// The `id!` macro generates a numeric id type that wraps a `u64`. The type implements common
@@ -20,8 +23,7 @@ macro_rules! id {
         $id:ident
     ) => {
         $(#[$meta])*
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, $crate::serde::Deserialize, $crate::serde::Serialize)]
         pub struct $id(u64);
 
         impl $id {
@@ -72,8 +74,7 @@ macro_rules! name {
         $name:ident
     ) => {
         $(#[$meta])*
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, $crate::serde::Deserialize, $crate::serde::Serialize)]
         pub struct $name(String);
 
         impl $name {
@@ -124,7 +125,6 @@ macro_rules! name {
 /// let token: ApiToken = "super-secret-api-token".into();
 /// let header = format!("Authorization: Bearer {}", token.expose());
 /// ```
-#[cfg(feature = "secret")]
 #[macro_export]
 macro_rules! secret {
     (
@@ -132,19 +132,18 @@ macro_rules! secret {
         $secret:ident
     ) => {
         $(#[$meta])*
-        #[derive(Clone, Debug)]
-        #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-        pub struct $secret(secrecy::SecretString);
+        #[derive(Clone, Debug, $crate::serde::Deserialize)]
+        pub struct $secret($crate::secrecy::SecretString);
 
         impl $secret {
             /// Initializes a new secret.
             pub fn new(secret: &str) -> Self {
-                Self(secrecy::SecretString::new(String::from(secret)))
+                Self($crate::secrecy::SecretString::new(String::from(secret)))
             }
 
             /// Returns the inner value of the secret.
             pub fn expose(&self) -> &str {
-                use secrecy::ExposeSecret;
+                use $crate::secrecy::ExposeSecret;
                 self.0.expose_secret()
             }
         }
@@ -157,13 +156,13 @@ macro_rules! secret {
 
         impl From<&str> for $secret {
             fn from(secret: &str) -> $secret {
-                $secret(secrecy::SecretString::new(String::from(secret)))
+                $secret($crate::secrecy::SecretString::new(String::from(secret)))
             }
         }
 
         impl From<String> for $secret {
             fn from(secret: String) -> $secret {
-                $secret(secrecy::SecretString::new(secret))
+                $secret($crate::secrecy::SecretString::new(secret))
             }
         }
     };


### PR DESCRIPTION
Some functionality was hidden behind the optional features `serde` and `secret`. The `cfg_attr` used with `serde` didn't work, though, causing build errors in consumer crates. It was not expanded inside the macro, and the consumer didn't have a matching feature enabled. Solving this problem is outside our current skill set, and not important for now (i.e. our own use case).